### PR TITLE
Add memory layer persistence on shutdown

### DIFF
--- a/cmd/resumption/main.go
+++ b/cmd/resumption/main.go
@@ -10,7 +10,13 @@ import (
 
 
 func main() {
-  db, err := badgerdb.New(os.Args[1])
+	var db dbpkg.Database
+	var err error
+	if len(os.Args) == 2 {
+		db, err = badgerdb.NewReadOnly(os.Args[1])
+	} else {
+		db, err = badgerdb.New(os.Args[1])
+	}
   if err != nil {
     log.Error("Error opening badgerdb", "error", err)
     os.Exit(1)

--- a/current/current_test.go
+++ b/current/current_test.go
@@ -255,3 +255,98 @@ func TestDepth(t *testing.T) {
     return nil
   }); err != nil { t.Errorf( "Unexpected error: %v", err )}
 }
+
+func TestCloseAndReopen(t *testing.T) {
+  db := mem.NewMemoryDatabase(1024)
+  s := New(db, 4, nil)
+  if err := s.AddBlock(
+    types.HexToHash("a"),
+    types.Hash{},
+    1,
+    big.NewInt(1),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("/a/Data"), Value: []byte("Something")},
+      storage.KeyValue{Key: []byte("/a/Data2"), Value: []byte("Something Else")},
+      storage.KeyValue{Key: []byte("a"), Value: []byte("1")},
+      storage.KeyValue{Key: []byte("b"), Value: []byte("2")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.AddBlock(
+    types.HexToHash("c"),
+    types.HexToHash("a"),
+    2,
+    big.NewInt(2),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("/a/Data"), Value: []byte("Something 2")},
+      storage.KeyValue{Key: []byte("/a/Data2"), Value: []byte("Something Else 2")},
+      storage.KeyValue{Key: []byte("b"), Value: []byte("3")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.AddBlock(
+    types.HexToHash("d"),
+    types.HexToHash("c"),
+    3,
+    big.NewInt(3),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("/a/Data"), Value: []byte("Something 2")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.AddBlock(
+    types.HexToHash("e"),
+    types.HexToHash("d"),
+    4,
+    big.NewInt(4),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("Data"), Value: []byte("Something 2")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.AddBlock(
+    types.HexToHash("f"),
+    types.HexToHash("e"),
+    5,
+    big.NewInt(5),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("Data"), Value: []byte("Something 2")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.AddBlock(
+    types.HexToHash("g"),
+    types.HexToHash("f"),
+    5,
+    big.NewInt(5),
+    []storage.KeyValue{
+      storage.KeyValue{Key: []byte("Data"), Value: []byte("Something 2")},
+    },
+    [][]byte{},
+    []byte("0"),
+  );  err != nil { t.Errorf(err.Error()) }
+  if err := s.Close(); err != nil {
+    t.Fatalf(err.Error())
+  }
+  var err error
+  s, err = Open(db, 4, nil)
+  if err != nil {
+    t.Fatalf(err.Error())
+  }
+  if err := s.View(types.HexToHash("g"), func(tr storage.Transaction) error {
+    if data, err := tr.Get([]byte("a")); err != nil {
+      t.Errorf("Error getting 'a': %v", err)
+      return err
+    } else if string(data) != "1" { t.Errorf("Unexpected value for a")}
+    if data, err := tr.Get([]byte("b")); err != nil {
+      t.Errorf("Error getting 'b': %v", err)
+      return err
+    } else if string(data) != "3" { t.Errorf("Unexpected value for b")}
+    return nil
+  }); err != nil { t.Errorf(err.Error() )}
+}

--- a/current/persist.go
+++ b/current/persist.go
@@ -1,0 +1,170 @@
+package current
+
+import (
+	"fmt"
+	"math/big"
+	"github.com/openrelayxyz/cardinal-types"
+	"github.com/openrelayxyz/cardinal-storage"
+	"github.com/hamba/avro"
+	"sync"
+)
+
+var (
+	persistLayerSchema = avro.MustParse(`{
+		"type": "array",
+		"name": "memLayers",
+		"avro.codec": "snappy",
+		"namespace": "cloud.rivet.cardinal.storage",
+		"items": {
+			"name": "layer",
+			"type": "record",
+			"fields": [
+				{"name": "parent", "type": {"name": "par", "type": "fixed", "size": 32}},
+				{"name": "number", "type": "long"},
+				{"name": "hash", "type": {"name": "h", "type": "fixed", "size": 32}},
+				{"name": "weight", "type": "bytes"},
+				{"name": "updates", "type": {
+					"type": "array",
+					"items": {
+						"name": "update",
+						"type": "record",
+						"fields": [
+						{"name": "key", "type": "bytes"},
+						{"name": "value", "type": "bytes"}
+						]
+					}
+				}},
+				{"name": "deletes", "type": {
+					"type": "array",
+					"items": "bytes"
+				}},
+				{"name": "resume", "type": "bytes"},
+				{"name": "children", "type": {
+					"type": "array",
+					"items": {
+						"name": "child",
+						"type": "fixed",
+						"size": 32
+					}
+				}}
+			]
+		}
+	}`)
+)
+
+
+type memLayerPersist struct{
+	Parent   types.Hash `avro:"parent"`
+	Number   int64      `avro:"number"`
+	Hash     types.Hash `avro:"hash"`
+	Weight   []byte     `avro:"weight"`
+	Updates  []storage.KeyValue `avro:"updates"`
+	Deletes  [][]byte   `avro:"deletes"`
+	Resume   []byte     `avro:"resume"`
+	Children []types.Hash `avro:"children"`
+}
+
+func preparePersist(layers map[types.Hash]layer) ([]byte, error) {
+	persistLayers := make([]memLayerPersist, 0, len(layers))
+	for _, v := range layers {
+		switch l := v.(type) {
+		case *memoryLayer:
+			children := make([]types.Hash, len(l.children))
+			for k := range l.children {
+				children = append(children, k)
+			}
+			persistLayers = append(persistLayers, memLayerPersist{
+				Parent: l.parentLayer().getHash(),
+				Number: int64(l.num),
+				Hash: l.hash,
+				Weight: l.blockWeight.Bytes(),
+				Updates: l.updates,
+				Deletes: l.deletes,
+				Children: children,
+				Resume: l.resume,
+			})
+		}
+	}
+	return avro.Marshal(persistLayerSchema, persistLayers)
+}
+
+func loadMap(m map[types.Hash]layer, persistenceData []byte, mut *sync.RWMutex) (types.Hash, error) {
+	var persistLayers []memLayerPersist
+	if err := avro.Unmarshal(persistLayerSchema, persistenceData, &persistLayers); err != nil {
+		return types.Hash{}, err
+	}
+	parents := make(map[types.Hash]types.Hash)
+	var heaviestHash types.Hash
+	heaviestWeight := new(big.Int)
+	for _, pl := range persistLayers {
+		parents[pl.Hash] = pl.Parent
+		l := &memoryLayer{
+			hash: pl.Hash,
+			parent: nil,
+			num: uint64(pl.Number),
+			blockWeight: new(big.Int).SetBytes(pl.Weight),
+			updatesMap: make(map[string][]byte),
+			updates: pl.Updates,
+			deletesMap: make(map[string]struct{}),
+			deletes: pl.Deletes,
+			resume: pl.Resume,
+			children: make(map[types.Hash]*memoryLayer),
+			mut: mut,
+		}
+		for _, kv := range pl.Updates {
+			l.updatesMap[string(kv.Key)] = kv.Value
+		}
+		for _, key := range pl.Deletes {
+			l.deletesMap[string(key)] = struct{}{}
+		}
+		m[pl.Hash] = l
+		if l.blockWeight.Cmp(heaviestWeight) > 0 {
+			heaviestWeight = l.blockWeight
+			heaviestHash = l.hash
+		}
+	}
+	for childHash, parentHash := range parents {
+		child := m[childHash]
+		parent, ok := m[parentHash]
+		if !ok { continue }
+		switch l := parent.(type) {
+		case *memoryLayer:
+			l.children[childHash] = child.(*memoryLayer)
+		case *diskLayer:
+			l.children[childHash] = child.(*memoryLayer)
+		}
+		l := child.(*memoryLayer)
+		l.parent = parent
+	}
+	foundDisk := false
+	for next := m[heaviestHash]; next != nil ; next = next.parentLayer() {
+		if next.persisted() {
+			foundDisk = true
+			break
+		}
+	}
+	for hash, l := range m {
+		if _, ok := parents[hash]; ok {
+			// Node is parent of something, so we'll get its depth elsewhere
+			continue
+		}
+		depth := int64(0)
+		for next := l; next != nil; next = next.parentLayer() {
+			switch v := next.(type) {
+			case *memoryLayer:
+				if v.depth < depth {
+					v.depth = depth
+				}
+			case *diskLayer:
+				if v.depth < depth {
+					v.depth = depth
+				}
+			}
+			depth++
+		}
+	}
+	if !foundDisk {
+		return types.Hash{}, fmt.Errorf("persisted layer not in ancestry of heaviest hash")
+	}
+	return heaviestHash, nil
+}

--- a/current/schema.go
+++ b/current/schema.go
@@ -14,6 +14,7 @@ var (
   ResumptionDataKey = []byte("Resumption")
   LatestBlockHashKey = []byte("LatestBlockHash")
   LatestBlockWeightKey = []byte("LatestBlockWeight")
+  MemoryPersistenceKey = []byte("MemoryPersistence")
 )
 
 

--- a/db/badgerdb/db.go
+++ b/db/badgerdb/db.go
@@ -24,6 +24,16 @@ func New(path string) (*Database, error) {
   return &Database{db: db}, error
 }
 
+func NewReadOnly(path string) (*Database, error) {
+  opt := badger.DefaultOptions(path)
+  if path == "" {
+    opt = opt.WithInMemory(true)
+  }
+	opt = opt.WithReadOnly(true)
+  db, error := badger.Open(opt)
+  return &Database{db: db}, error
+}
+
 type badgerTx struct {
   writable bool
   tx *badger.Txn

--- a/interface.go
+++ b/interface.go
@@ -7,8 +7,8 @@ import (
 )
 
 type KeyValue struct {
-  Key []byte
-  Value []byte
+  Key []byte   `avro:"key"`
+  Value []byte `avro:"value"`
 }
 
 func (kv KeyValue) String() string {
@@ -38,8 +38,12 @@ type Storage interface {
   // Roll back the storage engine to the specified block number in its history
   Rollback(uint64) error
 
-  // The resumption token of the current latest block
+  // LatestBlock returns the hash, height, weight, and resumption token of the
+  // latest block
   LatestBlock() (types.Hash, uint64, *big.Int, []byte)
+
+  // Close cleanly shuts down the storage interface.
+  Close() error
 }
 
 type Transaction interface {


### PR DESCRIPTION
Previously, we had planned to only persist the data from the disk
layer such that resumption would pick up from there and rebuild
the memory layer from cardinal-streams. The problem is that during
resumption, different partitions within the stream can get fairly
far out of sync with eachother, such that resuming from a resumption
token created while resuming from a stream often fails without a
very high rollback value.

In prior contexts this has never been an issue - we've always resumed
from the entire stream, and by that point the partitions are synced
back up. But without persisting the memory layer, the disk layer
represents data from the middle of the resumption process (~128 blocks
ago), which means the partitions are likely out of sync in the
resumption token. Persisting the memory layer means the resumption
token will come from a point where the partitions were synced.