### PR TITLE
Implement waiters

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -3,16 +3,62 @@ package archive
 import (
 	// "errors"
 	// "bytes"
+	"time"
 	"github.com/openrelayxyz/cardinal-storage"
 	"github.com/openrelayxyz/cardinal-storage/db/mem"
 	"github.com/openrelayxyz/cardinal-types"
 	"math/big"
 	"testing"
+	"sync"
 )
+
+type testWaiter struct {
+	hashes map[types.Hash]chan struct{}
+	number map[int64]chan struct{}
+	t *testing.T
+}
+
+func (w *testWaiter) WaitForHash(h types.Hash, d time.Duration) {
+	if _, ok := w.hashes[h]; !ok {
+		w.hashes[h] = make(chan struct{})
+	}
+	select {
+	case <-w.hashes[h]:
+	case <-time.After(d):
+		w.t.Errorf("Unexpected timeout waiting for hash")
+	}
+}
+func (w *testWaiter) WaitForNumber(n int64, d time.Duration) {
+	if _, ok := w.number[n]; !ok {
+		w.number[n] = make(chan struct{})
+	}
+	select {
+	case <-w.number[n]:
+	case <-time.After(d):
+		w.t.Errorf("Unexpected timeout waiting for number")
+	}
+}
+func (w *testWaiter) release(h types.Hash, n int64) {
+	if ch, ok := w.hashes[h]; ok {
+		close(ch)
+	}
+	if ch, ok := w.number[n]; ok {
+		close(ch)
+	}
+}
+
+func newTestWaiter(t *testing.T) *testWaiter {
+	return &testWaiter{
+		hashes: make(map[types.Hash]chan struct{}),
+		number: make(map[int64]chan struct{}),
+		t: t,
+	}
+}
 
 func TestAddBlock(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 8, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -92,6 +138,7 @@ func TestAddBlock(t *testing.T) {
 func TestFork(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 8, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -336,6 +383,7 @@ func TestDepth(t *testing.T) {
 func TestCloseAndReopen(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 4, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -444,4 +492,47 @@ func TestCloseAndReopen(t *testing.T) {
 	}); err != nil {
 		t.Errorf(err.Error())
 	}
+}
+func TestWaiterBlock(t *testing.T) {
+	db := mem.NewMemoryDatabase(1024)
+	s := New(db, 8, nil)
+	tw := newTestWaiter(t)
+	s.RegisterWaiter(tw, 250*time.Millisecond)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if h, _ := s.NumberToHash(1); h != types.HexToHash("a") {
+			t.Errorf("unexpected hash")
+		}
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		s.View(types.HexToHash("a"), func(tr storage.Transaction) error {
+			data, err := tr.Get([]byte("a"))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if string(data) != "1" {
+				t.Errorf("Unexpected data value")
+			}
+			return nil
+		})
+		wg.Done()
+	}()
+	if err := s.AddBlock(
+		types.HexToHash("a"),
+		types.Hash{},
+		1,
+		big.NewInt(1),
+		[]storage.KeyValue{
+			storage.KeyValue{Key: []byte("a"), Value: []byte("1")},
+		},
+		[][]byte{},
+		[]byte("0"),
+	); err != nil {
+		t.Errorf(err.Error())
+	}
+	tw.release(types.HexToHash("a"), 1)
+	wg.Wait()
 }

--- a/current/current_test.go
+++ b/current/current_test.go
@@ -3,16 +3,62 @@ package current
 import (
 	// "errors"
 	// "bytes"
+	"time"
 	"github.com/openrelayxyz/cardinal-storage"
 	"github.com/openrelayxyz/cardinal-storage/db/mem"
 	"github.com/openrelayxyz/cardinal-types"
 	"math/big"
 	"testing"
+	"sync"
 )
+
+type testWaiter struct {
+	hashes map[types.Hash]chan struct{}
+	number map[int64]chan struct{}
+	t *testing.T
+}
+
+func (w *testWaiter) WaitForHash(h types.Hash, d time.Duration) {
+	if _, ok := w.hashes[h]; !ok {
+		w.hashes[h] = make(chan struct{})
+	}
+	select {
+	case <-w.hashes[h]:
+	case <-time.After(d):
+		w.t.Errorf("Unexpected timeout waiting for hash")
+	}
+}
+func (w *testWaiter) WaitForNumber(n int64, d time.Duration) {
+	if _, ok := w.number[n]; !ok {
+		w.number[n] = make(chan struct{})
+	}
+	select {
+	case <-w.number[n]:
+	case <-time.After(d):
+		w.t.Errorf("Unexpected timeout waiting for number")
+	}
+}
+func (w *testWaiter) release(h types.Hash, n int64) {
+	if ch, ok := w.hashes[h]; ok {
+		close(ch)
+	}
+	if ch, ok := w.number[n]; ok {
+		close(ch)
+	}
+}
+
+func newTestWaiter(t *testing.T) *testWaiter {
+	return &testWaiter{
+		hashes: make(map[types.Hash]chan struct{}),
+		number: make(map[int64]chan struct{}),
+		t: t,
+	}
+}
 
 func TestAddBlock(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 8, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -92,6 +138,7 @@ func TestAddBlock(t *testing.T) {
 func TestFork(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 8, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -338,6 +385,7 @@ func TestDepth(t *testing.T) {
 func TestCloseAndReopen(t *testing.T) {
 	db := mem.NewMemoryDatabase(1024)
 	s := New(db, 4, nil)
+	s.RegisterWaiter(newTestWaiter(t), 250*time.Millisecond)
 	if err := s.AddBlock(
 		types.HexToHash("a"),
 		types.Hash{},
@@ -446,4 +494,49 @@ func TestCloseAndReopen(t *testing.T) {
 	}); err != nil {
 		t.Errorf(err.Error())
 	}
+}
+
+
+func TestWaiterBlock(t *testing.T) {
+	db := mem.NewMemoryDatabase(1024)
+	s := New(db, 8, nil)
+	tw := newTestWaiter(t)
+	s.RegisterWaiter(tw, 250*time.Millisecond)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if h, _ := s.NumberToHash(1); h != types.HexToHash("a") {
+			t.Errorf("unexpected hash")
+		}
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		s.View(types.HexToHash("a"), func(tr storage.Transaction) error {
+			data, err := tr.Get([]byte("a"))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if string(data) != "1" {
+				t.Errorf("Unexpected data value")
+			}
+			return nil
+		})
+		wg.Done()
+	}()
+	if err := s.AddBlock(
+		types.HexToHash("a"),
+		types.Hash{},
+		1,
+		big.NewInt(1),
+		[]storage.KeyValue{
+			storage.KeyValue{Key: []byte("a"), Value: []byte("1")},
+		},
+		[][]byte{},
+		[]byte("0"),
+	); err != nil {
+		t.Errorf(err.Error())
+	}
+	tw.release(types.HexToHash("a"), 1)
+	wg.Wait()
 }

--- a/db/boltdb/db.go
+++ b/db/boltdb/db.go
@@ -7,6 +7,7 @@ import (
 	bolt "github.com/boltdb/bolt"
 	log "github.com/inconshreveable/log15"
 	dbpkg "github.com/openrelayxyz/cardinal-storage/db"
+	"github.com/openrelayxyz/cardinal-storage"
 )
 
 type Database struct {
@@ -101,6 +102,9 @@ func (db *Database) Vacuum() bool {
 
 func (tx *boltTx) Get(key []byte) ([]byte, error) {
 	item := tx.bk.Get(key)
+	if item == nil {
+		return nil, storage.ErrNotFound
+	}
 	return item, nil
 }
 

--- a/interface.go
+++ b/interface.go
@@ -46,10 +46,19 @@ type Storage interface {
   // Close cleanly shuts down the storage interface.
   Close() error
 
+	RegisterWaiter(Waiter, time.Duration)
+
   // Vacuum frees space in the database. `rollback` indicates the number of
   // deltas to retain to support rollbacks, while gcTime is the an approximate
   // amount of time to spend on database level compaction.
   Vacuum(rollback uint64, gcTime time.Duration)
+
+	//
+}
+
+type Waiter interface {
+	WaitForHash(types.Hash, time.Duration)
+	WaitForNumber(int64, time.Duration)
 }
 
 type Initializer interface {
@@ -76,3 +85,7 @@ type Transaction interface {
 
 
 var EmptyHash = types.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+type NullWaiter struct{}
+
+func (NullWaiter) WaitForHash(types.Hash, time.Duration) {}
+func (NullWaiter) WaitForNumber(int64, time.Duration) {}


### PR DESCRIPTION
This allows applications to register Cardinal Streams waiters with Cardinal Storage, ensuring that if requests want to run against blocks that are in the middle of processing that the Cardinal Storage engine will wait for the blocks to finish processing before returning results.

This implements in both the Current and Archive storage. Applications have to call s.RegisterWaiter(watier, timeout) for waiters to take effect - a null waiter will be in place otherwise.

Both current and archive tests have been updated to account for waiters, and additional tests confirm waiter functionality is working as intended.